### PR TITLE
HTTP 캐시 활용하기 완료

### DIFF
--- a/cache/build.gradle
+++ b/cache/build.gradle
@@ -19,6 +19,11 @@ dependencies {
     implementation 'pl.allegro.tech.boot:handlebars-spring-boot-starter:0.3.4'
     implementation 'org.springframework.boot:spring-boot-starter-web:2.7.2'
     implementation 'org.springframework.boot:spring-boot-starter-webflux:2.7.2'
+    implementation("io.netty:netty-resolver-dns-native-macos:4.1.75.Final") {
+        artifact {
+            classifier = "osx-aarch_64"
+        }
+    }
     testImplementation 'org.springframework.boot:spring-boot-starter-test:2.7.2'
 }
 

--- a/cache/src/main/java/com/example/cachecontrol/CacheBustingInterceptor.java
+++ b/cache/src/main/java/com/example/cachecontrol/CacheBustingInterceptor.java
@@ -1,0 +1,24 @@
+package com.example.cachecontrol;
+
+import java.time.Duration;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.http.CacheControl;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.ModelAndView;
+
+public class CacheBustingInterceptor implements HandlerInterceptor {
+
+    @Override
+    public void postHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler,
+                           final ModelAndView modelAndView) throws Exception {
+        final String cacheControl = CacheControl
+                .maxAge(Duration.ofDays(365))
+                .cachePublic()
+                .getHeaderValue();
+
+        response.setHeader(HttpHeaders.CACHE_CONTROL, cacheControl);
+        HandlerInterceptor.super.postHandle(request, response, handler, modelAndView);
+    }
+}

--- a/cache/src/main/java/com/example/cachecontrol/CacheWebConfig.java
+++ b/cache/src/main/java/com/example/cachecontrol/CacheWebConfig.java
@@ -9,5 +9,7 @@ public class CacheWebConfig implements WebMvcConfigurer {
 
     @Override
     public void addInterceptors(final InterceptorRegistry registry) {
+        registry.addInterceptor(new NoCacheInterceptor())
+                .addPathPatterns("/");
     }
 }

--- a/cache/src/main/java/com/example/cachecontrol/CacheWebConfig.java
+++ b/cache/src/main/java/com/example/cachecontrol/CacheWebConfig.java
@@ -11,5 +11,7 @@ public class CacheWebConfig implements WebMvcConfigurer {
     public void addInterceptors(final InterceptorRegistry registry) {
         registry.addInterceptor(new NoCacheInterceptor())
                 .addPathPatterns("/");
+        registry.addInterceptor(new CacheBustingInterceptor())
+                .addPathPatterns("/resources/**");
     }
 }

--- a/cache/src/main/java/com/example/cachecontrol/NoCacheInterceptor.java
+++ b/cache/src/main/java/com/example/cachecontrol/NoCacheInterceptor.java
@@ -1,0 +1,20 @@
+package com.example.cachecontrol;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.http.CacheControl;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+public class NoCacheInterceptor implements HandlerInterceptor {
+    @Override
+    public void afterCompletion(final HttpServletRequest request, final HttpServletResponse response,
+                                final Object handler, final Exception ex)
+            throws Exception {
+        final String headerValue = CacheControl.noCache()
+                .cachePrivate()
+                .getHeaderValue();
+        response.addHeader(HttpHeaders.CACHE_CONTROL, headerValue);
+        HandlerInterceptor.super.afterCompletion(request, response, handler, ex);
+    }
+}

--- a/cache/src/main/java/com/example/etag/EtagFilterConfiguration.java
+++ b/cache/src/main/java/com/example/etag/EtagFilterConfiguration.java
@@ -11,7 +11,7 @@ public class EtagFilterConfiguration {
     @Bean
     public FilterRegistrationBean<ShallowEtagHeaderFilter> shallowEtagHeaderFilter() {
         final FilterRegistrationBean filterRegistrationBean = new FilterRegistrationBean(new ShallowEtagHeaderFilter());
-        filterRegistrationBean.addUrlPatterns("/etag");
+        filterRegistrationBean.addUrlPatterns("/etag", "/resources/*");
         return filterRegistrationBean;
     }
 }

--- a/cache/src/main/java/com/example/etag/EtagFilterConfiguration.java
+++ b/cache/src/main/java/com/example/etag/EtagFilterConfiguration.java
@@ -1,12 +1,17 @@
 package com.example.etag;
 
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.filter.ShallowEtagHeaderFilter;
 
 @Configuration
 public class EtagFilterConfiguration {
 
-//    @Bean
-//    public FilterRegistrationBean<ShallowEtagHeaderFilter> shallowEtagHeaderFilter() {
-//        return null;
-//    }
+    @Bean
+    public FilterRegistrationBean<ShallowEtagHeaderFilter> shallowEtagHeaderFilter() {
+        final FilterRegistrationBean filterRegistrationBean = new FilterRegistrationBean(new ShallowEtagHeaderFilter());
+        filterRegistrationBean.addUrlPatterns("/etag");
+        return filterRegistrationBean;
+    }
 }

--- a/cache/src/main/resources/application.yml
+++ b/cache/src/main/resources/application.yml
@@ -1,2 +1,8 @@
 handlebars:
   suffix: .html
+# Enable response compression
+server:
+  compression:
+    enabled: true
+    min-response-size: 100
+    mime-types: text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json

--- a/cache/src/main/resources/application.yml
+++ b/cache/src/main/resources/application.yml
@@ -4,5 +4,5 @@ handlebars:
 server:
   compression:
     enabled: true
-    min-response-size: 100
+    min-response-size: 200
     mime-types: text/html,text/xml,text/plain,text/css,text/javascript,application/javascript,application/json


### PR DESCRIPTION
1. 휴리스틱 캐싱 제거하기
인터셉터를 활용해서 no-chache, private를 Cache-control 헤더에 추가한다.

2. HTTP Compression 적용 (gzip)
application.yml에 압축 설정과 어느 정도 용량부터 압축할지를 작성.
다만 테스트 할 경우 로그에 잘 나오지 않게 된다.

3. Etag / If-none-Match 구현
FilterRegistrationBean과 ShallowEtagHeaderFilter를 활용해서 url 패턴 적용해주면 된다.

4. Cache Busting 적용
Cache Busting 할 url을 Etag를 사용하도록 설정하고(3번 참고), 인터셉터를 통해 cache-control에 max-age를 최대로 (1년)한다. 