### PR TITLE
Thread

### DIFF
--- a/thread/src/main/resources/application.yml
+++ b/thread/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 server:
   tomcat:
-    accept-count: 1
-    max-connections: 1
+    accept-count: 7
+    max-connections: 3
     threads:
       max: 2

--- a/thread/src/test/java/concurrency/stage0/SynchronizationTest.java
+++ b/thread/src/test/java/concurrency/stage0/SynchronizationTest.java
@@ -1,12 +1,11 @@
 package concurrency.stage0;
 
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
 
 /**
  * 다중 스레드 환경에서 두 개 이상의 스레드가 변경 가능한(mutable) 공유 데이터를 동시에 업데이트하면 경쟁 조건(race condition)이 발생한다.
@@ -41,7 +40,7 @@ class SynchronizationTest {
 
         private int sum = 0;
 
-        public void calculate() {
+        public synchronized void calculate() {
             setSum(getSum() + 1);
         }
 

--- a/thread/src/test/java/concurrency/stage0/ThreadPoolsTest.java
+++ b/thread/src/test/java/concurrency/stage0/ThreadPoolsTest.java
@@ -1,13 +1,12 @@
 package concurrency.stage0;
 
-import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
-
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * 스레드 풀은 무엇이고 어떻게 동작할까?
@@ -30,9 +29,8 @@ class ThreadPoolsTest {
         executor.submit(logWithSleep("hello fixed thread pools"));
         executor.submit(logWithSleep("hello fixed thread pools"));
 
-        // 올바른 값으로 바꿔서 테스트를 통과시키자.
-        final int expectedPoolSize = 0;
-        final int expectedQueueSize = 0;
+        final int expectedPoolSize = 2;     // 스레드 풀의 크기를 의미한다.
+        final int expectedQueueSize = 1;    // 현재 대기 중인 작업의 크기(개수)를 의미한다.
 
         assertThat(expectedPoolSize).isEqualTo(executor.getPoolSize());
         assertThat(expectedQueueSize).isEqualTo(executor.getQueue().size());
@@ -45,8 +43,7 @@ class ThreadPoolsTest {
         executor.submit(logWithSleep("hello cached thread pools"));
         executor.submit(logWithSleep("hello cached thread pools"));
 
-        // 올바른 값으로 바꿔서 테스트를 통과시키자.
-        final int expectedPoolSize = 0;
+        final int expectedPoolSize = 3;
         final int expectedQueueSize = 0;
 
         assertThat(expectedPoolSize).isEqualTo(executor.getPoolSize());


### PR DESCRIPTION
## 스레드 풀

- `final var executor = (ThreadPoolExecutor) Executors.**newFixedThreadPool**(2);`
    - 고정된 크기의 스레드 풀을 생성한다.
    - 스레드 풀에서 사용 가능한 스레드가 없으면 요청은 작업 큐로 들어가 대기한다.
    
    ![Untitled](https://s3-us-west-2.amazonaws.com/secure.notion-static.com/218200d9-fe43-41f4-a653-734583257e4b/Untitled.png)
    
- `final var executor = (ThreadPoolExecutor) Executors.**newCachedThreadPool**();`
    - 요청이 들어오면 스레드 풀에서 사용 가능한 스레드를 사용한다.
    - 사용 가능한 스레드가 없다면 새 스레드를 생성해 스레드 풀에 넣는다.
    - 따라서 스레드 풀의 사이즈가 유동적이다. (처음 사이즈는 0이다.)
    - 스레드 풀에서 60초 동안 사용되지 않은 스레드는 제거된다.
    
    ![Untitled](https://s3-us-west-2.amazonaws.com/secure.notion-static.com/918e991c-fcbf-4548-a919-9a4577668e3a/Untitled.png)
    

## Tomcat HTTP Connector Attributes

- [https://tomcat.apache.org/tomcat-8.5-doc/config/http.html](https://tomcat.apache.org/tomcat-8.5-doc/config/http.html)

### accept count

- 서버가 최대 연결 개수에 도달한 이후, 허용할 수 있는 연결 개수를 말한다.
    - 기본값은 100이다.
- 작업 대기 큐의 사이즈와 같다고 볼 수 있다.
    - 요청이 들어왔을 때 이를 처리할 수 있는 스레드가 없다면 작업 대기 큐에 들어간다.
    - 작업 대기 큐가 꽉 차있다면 해당 요청은 무시된다.
- 운영체제에 따라 해당 속성을 무시하고 작업 대기 큐의 사이즈를 다르게 설정할 수 있다.

### max connections

- 서버가 연결을 허용(accept)하고 처리(precess)할 수 있는 최대 연결 개수이다.
- 최대 연결 개수에 도달하면, 서버는 추가 연결을 허용하지만 이를 바로 처리하지는 않는다.
    - 허용 연결 수는 accept count를 따른다.
- NIO, NIO2에서의 기본값은 10_000이다.

### max threads

- 서버에서 동시에 실행할 수 있는 스레드의 개수를 의미한다.
- 동시에 처리할 수 있는 요청의 수와 같다.
- 기본값은 200이다.

### 만약 거의 동시에 10개의 요청이 들어오는 상황을 가정해보자.

```yaml
server:
  tomcat:
    accept-count: 3
    max-connections: 3
    threads:
      max: 3
```

![Untitled](https://s3-us-west-2.amazonaws.com/secure.notion-static.com/a94f9acf-bfb6-4931-9069-44b77ef8955e/Untitled.png)

- 6개의 요청까지만 처리된다.
- 이는 max threads와 상관없이 accept count와 max connections 설정의 문제이다.
- 10개의 요청이 오면
    1. max connections에 따라 일단 먼저 들어온 3개의 요청을 받아들이고, accept count에 따라 그 뒤에 들어온 3개의 요청을 작업 대기 큐에 넣는다. 
    2. 나머지 4개의 요청을 무시된다. (버려짐!)
    3. max threads에 따라 동시에 3개의 스레드가 돌면서 요청이 처리된다.

```yaml
server:
  tomcat:
    accept-count: 0
    max-connections: 10
    threads:
      max: 1
```

![Untitled](https://s3-us-west-2.amazonaws.com/secure.notion-static.com/6a4f63b3-3d37-4259-a6dc-9ac4571191a4/Untitled.png)

- max connections가 충분하면 accept count가 0이어도 모든 요청을 처리할 수 있다.

```yaml
server:
  tomcat:
    accept-count: 0
    max-connections: 10
    threads:
      max: 10
```

![Untitled](https://s3-us-west-2.amazonaws.com/secure.notion-static.com/a299d5ff-0ac7-4317-a60e-ed51d6061d75/Untitled.png)

- 스레드가 충분하면 요청을 빠른 시간 안에 처리할 수 있다.